### PR TITLE
Gives the options to make images behave in a similar manner

### DIFF
--- a/dist/GestureView.js
+++ b/dist/GestureView.js
@@ -30,7 +30,9 @@ exports['default'] = _reactNative2['default'].createClass({
     onError: _reactNative.PropTypes.func.isRequired,
     toStyle: _reactNative.PropTypes.func.isRequired,
     style: _reactNative.PropTypes.any,
-    children: _reactNative.PropTypes.array
+    children: _reactNative.PropTypes.array,
+    type: _reactNative.PropTypes.string,
+    source: _reactNative.PropTypes.any
   },
 
   componentDidMount: function componentDidMount() {
@@ -57,13 +59,18 @@ exports['default'] = _reactNative2['default'].createClass({
         var nativeEvent = _ref.nativeEvent;
 
         _this2.onLayout.onNext(nativeEvent);
-      }
+      },
+      type: this.props.type || 'View',
+      source: this.props.source
     }, this.gestureResponder.panHandlers);
-
     return _reactNative2['default'].createElement(
       _reactNative.View,
-      props,
-      this.props.children
+      null,
+      this.props.type === 'View' ? _reactNative2['default'].createElement(
+        _reactNative.View,
+        props,
+        this.props.children
+      ) : _reactNative2['default'].createElement(_reactNative.Image, props)
     );
   }
 });

--- a/dist/GestureView.js
+++ b/dist/GestureView.js
@@ -31,7 +31,7 @@ exports['default'] = _reactNative2['default'].createClass({
     toStyle: _reactNative.PropTypes.func.isRequired,
     style: _reactNative.PropTypes.any,
     children: _reactNative.PropTypes.array,
-    type: _reactNative.PropTypes.string,
+    type: _reactNative.PropTypes.oneOf(['View', 'Image']),
     source: _reactNative.PropTypes.any
   },
 

--- a/dist/create.js
+++ b/dist/create.js
@@ -4,7 +4,11 @@ Object.defineProperty(exports, '__esModule', {
   value: true
 });
 
-var _ramda = require('ramda');
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { 'default': obj }; }
+
+var _curry = require('curry');
+
+var _curry2 = _interopRequireDefault(_curry);
 
 function createGesture(responder, transducer, getInitialLayout, draggable) {
   return draggable.onDragStart.flatMap(function () {
@@ -12,5 +16,5 @@ function createGesture(responder, transducer, getInitialLayout, draggable) {
   });
 };
 
-exports['default'] = (0, _ramda.curry)(createGesture);
+exports['default'] = (0, _curry2['default'])(createGesture);
 module.exports = exports['default'];

--- a/dist/responder/general.js
+++ b/dist/responder/general.js
@@ -11,7 +11,6 @@
 Object.defineProperty(exports, '__esModule', {
   value: true
 });
-exports['default'] = genernalResponder;
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { 'default': obj }; }
 
@@ -22,6 +21,10 @@ var _rx2 = _interopRequireDefault(_rx);
 var _immutable = require('immutable');
 
 var _immutable2 = _interopRequireDefault(_immutable);
+
+var _curry = require('curry');
+
+var _curry2 = _interopRequireDefault(_curry);
 
 function toImmutableTouch(touch) {
   return _immutable2['default'].Map({
@@ -79,4 +82,5 @@ function genernalResponder(n, onMove, getInitialLayout) {
   });
 }
 
+exports['default'] = (0, _curry2['default'])(genernalResponder);
 module.exports = exports['default'];

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
   "dependencies": {
     "curry": "^1.2.0",
     "immutable": "^3.7.5",
+    "ramda": "^0.19.1",
     "rx": "^4.0.6",
     "transducers.js": "^0.3.2"
   },

--- a/src/GestureView.js
+++ b/src/GestureView.js
@@ -15,7 +15,10 @@ export default React.createClass({
     toStyle: PropTypes.func.isRequired,
     style: PropTypes.any,
     children: PropTypes.array,
-    type: PropTypes.string,
+    type: PropTypes.oneOf([
+      'View',
+      'Image'
+    ]),
     source: PropTypes.any
   },
 

--- a/src/GestureView.js
+++ b/src/GestureView.js
@@ -2,7 +2,8 @@ import events from './mixins/events'
 import draggableMixin from './mixins/draggable'
 import React, {
   PropTypes,
-  View
+  View,
+  Image
 } from 'react-native'
 
 export default React.createClass({
@@ -13,7 +14,9 @@ export default React.createClass({
     onError: PropTypes.func.isRequired,
     toStyle: PropTypes.func.isRequired,
     style: PropTypes.any,
-    children: PropTypes.array
+    children: PropTypes.array,
+    type: PropTypes.string,
+    source: PropTypes.any
   },
 
   componentDidMount () {
@@ -32,12 +35,19 @@ export default React.createClass({
       onLayout: ({nativeEvent}) => {
         this.onLayout.onNext(nativeEvent)
       },
+      type: this.props.type || 'View',
+      source: this.props.source,
       ...this.gestureResponder.panHandlers
     }
-
     return (
-      <View {...props}>
-        {this.props.children}
+      <View>
+        {this.props.type === 'View' ? (
+          <View {...props}>
+            {this.props.children}
+          </View>
+        ) : (
+          <Image {...props} />
+        )}
       </View>
     )
   }


### PR DESCRIPTION
If I wrapped GestureView around an image, I couldn't get my image to behave in the same manner as the demo. I simply added another prop called type and allowed you to pass in a string of image which then allows you to have the same effects with an image. 
