### PR TITLE
Rotations no longer reset

### DIFF
--- a/dist/drag.js
+++ b/dist/drag.js
@@ -16,12 +16,11 @@ var responder = _responderOneFinger2['default'];
 
 exports.responder = responder;
 var transducer = (0, _transducersJs.map)(function (gesture) {
-  var layout = gesture.get('initialLayout').set('rotate', 0);
+  var layout = gesture.get('initialLayout');
   var initialTouch = gesture.get('initialTouches').get(0);
   var currentTouch = gesture.get('touches').get(0);
-
   return layout.withMutations(function (l) {
-    return l.set('x', l.get('x') + (currentTouch.get('pageX') - initialTouch.get('pageX'))).set('y', l.get('y') + (currentTouch.get('pageY') - initialTouch.get('pageY')));
+    return l.set('x', l.get('x') + (currentTouch.get('pageX') - initialTouch.get('pageX'))).set('y', l.get('y') + (currentTouch.get('pageY') - initialTouch.get('pageY'))).set('rotate', l.get('rotate'));
   }).toJS();
 });
 exports.transducer = transducer;

--- a/dist/mixins/draggable.js
+++ b/dist/mixins/draggable.js
@@ -17,9 +17,9 @@ var _create2 = _interopRequireDefault(_create);
 
 var _reactNative = require('react-native');
 
-function yes() {
+var yes = function yes() {
   return true;
-}
+};
 
 function draggableMixin(gestureDefs) {
   gestureDefs = gestureDefs || [];

--- a/dist/pinch.js
+++ b/dist/pinch.js
@@ -26,7 +26,6 @@ var transducer = (0, _transducersJs.map)(function (gesture) {
   var newWidth = startWidth * scale;
   var xWidthDiff = (newWidth - startWidth) / 2;
   var yHeightDiff = (newHeight - startHeight) / 2;
-
   return {
     x: startX - gesture.getIn(['centerDiff', 'x']) - xWidthDiff,
     y: startY - gesture.getIn(['centerDiff', 'y']) - yHeightDiff,

--- a/dist/responder/twoFinger.js
+++ b/dist/responder/twoFinger.js
@@ -66,6 +66,8 @@ function angle(touches) {
 }
 
 function mutate(gesture) {
+  console.log(gesture);
+  console.log(gesture.get('initialLayout'));
   var initCenter = center(gesture.get('initialTouches'));
   var currentCenter = center(gesture.get('touches'));
   var initDistance = distance(gesture.get('initialTouches'));

--- a/dist/responder/twoFinger.js
+++ b/dist/responder/twoFinger.js
@@ -66,8 +66,6 @@ function angle(touches) {
 }
 
 function mutate(gesture) {
-  console.log(gesture);
-  console.log(gesture.get('initialLayout'));
   var initCenter = center(gesture.get('initialTouches'));
   var currentCenter = center(gesture.get('touches'));
   var initDistance = distance(gesture.get('initialTouches'));

--- a/package.json
+++ b/package.json
@@ -39,7 +39,6 @@
   "dependencies": {
     "curry": "^1.2.0",
     "immutable": "^3.7.5",
-    "ramda": "^0.19.1",
     "rx": "^4.0.6",
     "transducers.js": "^0.3.2"
   },

--- a/src/drag.js
+++ b/src/drag.js
@@ -4,15 +4,15 @@ import oneFingerResponder from './responder/oneFinger'
 export let responder = oneFingerResponder
 
 export let transducer = map(function (gesture) {
-  let layout = gesture.get('initialLayout').set('rotate', 0)
+  let layout = gesture.get('initialLayout')
   let initialTouch = gesture.get('initialTouches').get(0)
   let currentTouch = gesture.get('touches').get(0)
-
   return layout.withMutations(function (l) {
     return l
       .set('x', l.get('x') +
         (currentTouch.get('pageX') - initialTouch.get('pageX')))
       .set('y', l.get('y') +
         (currentTouch.get('pageY') - initialTouch.get('pageY')))
+      .set('rotate', l.get('rotate'))
   }).toJS()
 })

--- a/src/mixins/draggable.js
+++ b/src/mixins/draggable.js
@@ -2,7 +2,7 @@ import Rx from 'rx'
 import create from '../create'
 import { PanResponder } from 'react-native'
 
-function yes () { return true }
+const yes = () => true;
 
 export default function draggableMixin (gestureDefs) {
   gestureDefs = gestureDefs || []

--- a/src/pinch.js
+++ b/src/pinch.js
@@ -14,7 +14,6 @@ export let transducer = map(function (gesture) {
   let newWidth = startWidth * scale
   let xWidthDiff = (newWidth - startWidth) / 2
   let yHeightDiff = (newHeight - startHeight) / 2
-
   return {
     x: startX - gesture.getIn(['centerDiff', 'x']) - xWidthDiff,
     y: startY - gesture.getIn(['centerDiff', 'y']) - yHeightDiff,


### PR DESCRIPTION
I guess it really depends what you're trying to accomplish with this tool, but I found that reseting the rotation of the image was irritating. Now you can rotate the image/view and then drag it to where you want the center to be. The only problem I'm having is that I can't seem to get the view/image rotation when I initiate a two touch action. So the view/image resets the rotation when initiating a new two touch action. Do you know how to expose the current rotation so that I can set that as the initial rotation of the view/image? 
